### PR TITLE
Fix donation link to avoid HTTP redirect hop

### DIFF
--- a/_misc/give.html
+++ b/_misc/give.html
@@ -134,7 +134,7 @@ height="1">
 
 <p>You know what it means for a teenager to find something they're passionate to learn: it's the key to discovering a lifetime of learning. With our <b>Splash</b> model, students everywhere can experience this change. Your donation helps start programs that will last for decades at universities across the nation. All donations go towards supporting the infrastructure that Splash needs: the website system, mentoring and teacher training, and shared resources that help the programs run so smoothly.</p>
 
-<p><a href="/donatenow">Click here</a> to donate now by credit/debit card.</p>
+<p><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=53TD5UYZ9LVXY&source=url">Click here</a> to donate now by credit/debit card.</p>
 
 <p>For more information, please see our <a href="/media/docs/annualreport2011.pdf">annual report</a>.</p>
 


### PR DESCRIPTION
**Problem**

The “donate” click path goes through https://www.learningu.org/donatenow which redirects to http://www.learningu.org/donatenow/ before sending people to PayPal. Even though PayPal is HTTPS, the HTTP hop is unnecessary and not ideal.

On /give/, donate link points to /donatenow (no trailing slash), which in production redirects via http://www.learningu.org/donatenow/ before PayPal.

**Steps to reproduce** 

1. Go to https://www.learningu.org/give/ Click “Click here to donate now…” Observe redirect behavior that includes an HTTP URL.

**Fix**  

-  Updated donate link to use (choose one):

- direct HTTPS PayPal URL,

**Testing:**

Local: make serve, verified /give/ donate link target updated and navigation works.

**Production validation plan after deployment**:

Confirm no http://www.learningu.org/donatenow/  appears in the redirect chain when starting from /give/.