### PR TITLE
Fix privacy policy canonical URL + redirect /about/privacy/ → /privacy/

### DIFF
--- a/_about/privacy.html
+++ b/_about/privacy.html
@@ -2,6 +2,7 @@
 layout: default
 permalink: /about/privacy/
 title: Privacy Policy
+redirect_from: /privacy/
 ---
 
 <div class="page-hero">


### PR DESCRIPTION
### DESCRIPTION

This PR resolves conflicting Privacy Policy pages by making /privacy/ the single canonical policy URL and redirecting /about/privacy/ to /privacy/.
It also ensures the contact email is displayed as plain text for accessibility.

### RELATED ISSUE

Closes #18 

### WHAT CHANGED

- Updated _misc/privacy.html so /privacy/ contains the full detailed policy (canonical page)
- Updated _about/privacy.md to redirect to /privacy/
- Replaced the email image with plain text info@learningu.org on the canonical page

### WHY THIS MATTERS

Having multiple policy URLs with different content is confusing and can leave outdated policy text publicly indexed. A single canonical page reduces risk and improves clarity.

### TESTING

1.  Ran make serve
2.  Verified /privacy/ renders the full policy locally
3.  Verified /about/privacy/ redirects to /privacy/ locally
4.  Verified email appears as selectable text (not image)