### PR TITLE
Replace Twitter bird icon with X logo across site

### DIFF
--- a/_contact/index.html
+++ b/_contact/index.html
@@ -12,5 +12,5 @@ permalink: /contact/
    <li>E-mail: <img src="/media/images/content-pages/email.jpg" height="20" width="124" valign=top></li>
    <li>Phone: (617) 379-0178</li>
    <li>Our <a href ="https://www.facebook.com/Learning-Unlimited-148451064087/">Facebook page</a></li>
-<li> <a href ="https://twitter.com/LUMakeASplash">Follow us</a> on Twitter</li>
+<li> <a href ="https://x.com/LUMakeASplash">Follow us</a> on X</li>
 </ul>

--- a/_current-programs/index.html
+++ b/_current-programs/index.html
@@ -10,7 +10,7 @@ redirect_from:
 <!-- Wish these could be in head! -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.js" type="text/javascript" charset="utf-8"></script>
 <div class="qsd_view_visible prettify" id="inline_qsd_5780daf6">
-    <script src="https://kit.fontawesome.com/a30de12fa8.js" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@200;300;400;500;600;700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Montserrat&display=swap" rel="stylesheet">
 
@@ -325,7 +325,7 @@ redirect_from:
                         <td>
                             <button type="button" class="social_button">
         <a href="https://twitter.com/SplashCornell">
-          <i class="fab fa-twitter fa-2x" style="color: white;" aria-hidden="true"></i></a>
+          <i class="fa-brands fa-x-twitter fa-2x" style="color: white;" aria-hidden="true"></i></a>
     </button><br></td>
                         <td>
                             <button type="button" class="social_button">
@@ -403,7 +403,7 @@ redirect_from:
                         <td>
                             <button type="button" class="social_button">
         <a href="https://twitter.com/nuneptun">
-          <i class="fab fa-twitter fa-2x" style="color: white;" aria-hidden="true"></i></a>
+          <i class="fa-brands fa-x-twitter fa-2x" style="color: white;" aria-hidden="true"></i></a>
     </button><br></td>
                         <td>
                             <button type="button" class="social_button">
@@ -490,7 +490,7 @@ redirect_from:
                                 <td>
                                     <button type="button" class="social_button">
         <a href="https://twitter.com/splashchicago">
-          <i class="fab fa-twitter fa-2x" style="color: white;" aria-hidden="true"></i></a>
+          <i class="fa-brands fa-x-twitter fa-2x" style="color: white;" aria-hidden="true"></i></a>
     </button><br></td>
                                 <td>
                                     <button type="button" class="social_button">
@@ -724,7 +724,7 @@ redirect_from:
                                 <td>
                                     <button type="button" class="social_button">
         <a href="https://twitter.com/StanfordSPLASH/">
-          <i class="fab fa-twitter fa-2x" style="color: white;" aria-hidden="true"></i></a>
+          <i class="fa-brands fa-x-twitter fa-2x" style="color: white;" aria-hidden="true"></i></a>
     </button><br></td>
                                 <td>
                                     <button type="button" class="social_button">


### PR DESCRIPTION
## Summary
Twitter rebranded to X in 2023. This PR updates all Twitter references 
to use the correct X branding and ensures the icon renders properly.

## Problem
- The old `fab fa-twitter` icon class was used across the Current Programs page
- The Font Awesome kit (`a30de12fa8.js`) was locked to an older version 
  that did not include the `fa-x-twitter` icon (added in FA 6.4.0), 
  causing the icon to not render at all

## Changes

### `_current-programs/index.html`
- Replaced Font Awesome kit script with **Font Awesome 6.7.2** CDN link 
  from cdnjs to guarantee `fa-x-twitter` is available
- Replaced all 4 instances of `fab fa-twitter` with `fa-brands fa-x-twitter`

### `_contact/index.html`
- Updated "Follow us on Twitter" → "Follow us on X"
- Updated link URL from `twitter.com/LUMakeASplash` → `x.com/LUMakeASplash`

## Files Changed
- `_current-programs/index.html`
- `_contact/index.html`

## Testing
- [ ] X icons render correctly on `/current-programs/` for all 4 program 
      cards (Cornell, NU, Chicago, Stanford)
- [ ] Contact page shows "Follow us on X" with correct `x.com` link
- [ ] All other Font Awesome icons (Facebook, Instagram, envelope, etc.) 
      still render correctly after the CDN switch
## Fixed #30 


<img width="1470" height="956" alt="Screenshot 2026-03-07 at 1 25 54 PM" src="https://github.com/user-attachments/assets/01225c16-ebad-42c5-8181-15d75db9158e" />
