### PR TITLE
Make email and phone clickable using mailto: and tel:

### DIFF
--- a/_contact/index.html
+++ b/_contact/index.html
@@ -9,8 +9,8 @@ permalink: /contact/
 <p>If you are interested in hearing more about Learning Unlimited, we would love to talk to you!  Please reach us by:</p>
 
 <ul>
-   <li>E-mail: <img src="/media/images/content-pages/email.jpg" height="20" width="124" valign=top></li>
-   <li>Phone: (617) 379-0178</li>
+   <li>E-mail: <a href="mailto:info@learningu.org">info@learningu.org</a></li>
+   <li>Phone:  <a href="tel:+6173790178">(617) 379-0178</a></li>  
    <li>Our <a href ="https://www.facebook.com/Learning-Unlimited-148451064087/">Facebook page</a></li>
 <li> <a href ="https://twitter.com/LUMakeASplash">Follow us</a> on Twitter</li>
 </ul>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,7 +3,12 @@
       <div id="footer">
 	<div class="hr"><hr/></div>
 
-        <img src="/media/images/content-pages/footer.gif" alt="Learning Unlimited / info@learningu.org / 617-379-0178" />
+    <p class="footer-contact">
+  LEARNING UNLIMITED &nbsp;•&nbsp;
+  <a href="mailto:info@learningu.org">INFO@LEARNINGU.ORG</a>
+  &nbsp;•&nbsp;
+  <a href="tel:+16173790178">617-379-0178</a>
+</p>
       </div>
     </div>
 

--- a/media/css/content-pages.css
+++ b/media/css/content-pages.css
@@ -51,6 +51,24 @@ div#header div.hr, div#footer div.hr
     border: none;
 }
 
+.footer-contact {
+  text-align: center;
+  font-size: 14px;       
+  letter-spacing: 2px;
+  color: #6a7fa0;
+  margin: 18px 0;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+.footer-contact a {
+  color: #6a7fa0;
+  text-decoration: none;
+}
+
+.footer-contact a:hover {
+  color: #e6504b;
+}
+
 div#header div.hr
 {
     margin-bottom: 0.5em;


### PR DESCRIPTION
Fixes #28 

This PR replaces the contact page and footer contact GIF with semantic HTML links while keeping the visual design consistent.

Changes:
- Added clickable `mailto:` link for the email address
- Added clickable `tel:` link for the phone number
- Added minimal CSS to preserve the original styling

Benefits:
- Users can directly open their mail client
- Phone number opens dialer on mobile devices
- Improves accessibility by removing text embedded in images