### PR TITLE
Add missing LU site logo

### DIFF
--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -3,8 +3,8 @@
 <head>
   <title>{{ page.title }}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-   <link rel="stylesheet" href="../media/css/index.css">
-   <link rel="icon" href="../media/images/favicon.ico">
+  <link rel="stylesheet" href="../media/css/index.css">
+  <link rel="icon" href="../media/images/favicon.ico">
 </head>
 
 <body>


### PR DESCRIPTION
This PR adds the missing LU site logo that was accidentally omitted in the previous PR. The logo has been added to the site header and as a favicon in the browser tab.

before :
<img width="119" height="38" alt="image" src="https://github.com/user-attachments/assets/bcda29ee-2c26-41a9-af45-3a9304f7c288" />

after : 

<img width="114" height="36" alt="image" src="https://github.com/user-attachments/assets/0af4ad8a-67d2-48e7-8778-62dde7bbcba3" />
