### PR TITLE
feat: added the dark and light theme functionality

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -37,7 +37,7 @@
 
 
       <li class="nav-theme">
-      <button type="button" id="theme-toggle" class="theme-toggle-btn" aria-label="Toggle Theme" aria-pressed="false">
+      <button type="button" id="theme-toggle" class="theme-toggle-btn" aria-label="Switch to dark mode" aria-pressed="false">
              <span id="theme-icon">🌙</span>
              <span id="theme-text">Dark Mode</span>
       </button>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -33,13 +33,16 @@
         style="color:white;background:var(--accent);"
       >Donate ↗</a>
         
-      <li class="nav-theme  ">
-      <button type="button" id="theme-toggle" class="theme-toggle-btn " aria-label="Toggle Theme">
+    </li>
+
+
+      <li class="nav-theme">
+      <button type="button" id="theme-toggle" class="theme-toggle-btn" aria-label="Toggle Theme" aria-pressed="false">
              <span id="theme-icon">🌙</span>
              <span id="theme-text">Dark Mode</span>
       </button>
       </li>
-    </li>
+    
   </ul>
 
 </nav>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -32,6 +32,13 @@
         rel="noopener"
         style="color:white;background:var(--accent);"
       >Donate ↗</a>
+        
+      <li>
+      <button type="button" id="theme-toggle" class="theme-toggle-btn " aria-label="Toggle Theme">
+             <span id="theme-icon">🌙</span>
+             <span id="theme-text">Dark Mode</span>
+      </button>
+      </li>
     </li>
   </ul>
 

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -33,7 +33,7 @@
         style="color:white;background:var(--accent);"
       >Donate ↗</a>
         
-      <li>
+      <li class="nav-theme  ">
       <button type="button" id="theme-toggle" class="theme-toggle-btn " aria-label="Toggle Theme">
              <span id="theme-icon">🌙</span>
              <span id="theme-text">Dark Mode</span>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -51,6 +51,18 @@
 
   <link rel="icon" href="/media/images/favicon.ico">
   <link rel="manifest" href="/media/images/site.webmanifest">
+
+  <script>
+
+  (function () {
+    var theme = 'light';
+    try {
+      var stored = localStorage.getItem('theme');
+      if (stored === 'dark' || stored === 'light') theme = stored;
+    } catch (e) { /* storage blocked */ }
+    document.documentElement.setAttribute('data-theme', theme);
+  })();
+</script>
 </head>
 
 <body>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -64,6 +64,6 @@
 
   <script src="/assets/js/mailing-list.js"></script>
   <script src="/assets/js/main.js"></script>
-
+  <script src="{{ '/assets/js/themeSwitcher.js' | relative_url }}"></script>
 </body>
 </html>

--- a/assets/js/themeSwitcher.js
+++ b/assets/js/themeSwitcher.js
@@ -3,53 +3,34 @@ document.addEventListener('DOMContentLoaded', () => {
   const themeIcon = document.getElementById('theme-icon');
   const themeText = document.getElementById('theme-text');
 
-  // Safe storage helpers — never throw, even if localStorage is blocked
-  const getStoredTheme = () => {
-    try {
-      return localStorage.getItem('theme');
-    } catch {
-      return null;
-    }
-  };
-
   const setStoredTheme = (theme) => {
     try {
       localStorage.setItem('theme', theme);
     } catch {
-      // Storage unavailable — theme just won't persist, no crash
+      // Storage unavailable 
     }
   };
 
-  // Normalize whatever we read into exactly 'light' or 'dark'
-  const normalizeTheme = (value) => (value === 'dark' ? 'dark' : 'light');
-
-  // 1. Check local storage for saved theme, default to 'light'
-  const currentTheme = normalizeTheme(getStoredTheme());
-
-  // 2. Apply the saved theme on initial load
-  document.documentElement.setAttribute('data-theme', currentTheme);
-
-  // 3. Update the button UI on initial load (guard against missing elements)
+  // Sync the button UI with the theme already applied by the inline <head> script
   const updateButtonUI = (theme) => {
-    if (themeIcon) themeIcon.textContent = theme === 'dark' ? '☀️' : '🌙';
-    if (themeText) themeText.textContent = theme === 'dark' ? 'Light Mode' : 'Dark Mode';
-    // Tell assistive tech the current state
-    if (themeToggle) themeToggle.setAttribute('aria-pressed', theme === 'dark' ? 'true' : 'false');
+    const isDark = theme === 'dark';
+    if (themeIcon) themeIcon.textContent = isDark ? '☀️' : '🌙';
+    if (themeText) themeText.textContent = isDark ? 'Light Mode' : 'Dark Mode';
+    if (themeToggle) themeToggle.setAttribute('aria-pressed', isDark ? 'true' : 'false');
   };
 
-  updateButtonUI(currentTheme);
+  updateButtonUI(document.documentElement.getAttribute('data-theme') || 'light');
 
-  // 4. Listen for button clicks to swap themes
   if (themeToggle) {
     themeToggle.addEventListener('click', (e) => {
       e.preventDefault();
 
-      const theme = document.documentElement.getAttribute('data-theme');
+      const theme = document.documentElement.getAttribute('data-theme') || 'light';
       const newTheme = theme === 'dark' ? 'light' : 'dark';
 
       document.documentElement.setAttribute('data-theme', newTheme);
-      setStoredTheme(newTheme); // Safe write — won't throw
+      setStoredTheme(newTheme);
       updateButtonUI(newTheme);
     });
-  }
+  } 
 });

--- a/assets/js/themeSwitcher.js
+++ b/assets/js/themeSwitcher.js
@@ -1,0 +1,42 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const themeToggle = document.getElementById('theme-toggle');
+  const themeIcon = document.getElementById('theme-icon');
+  const themeText = document.getElementById('theme-text');
+  
+  // Helper function to update the button's text and icon
+  const updateButtonUI = (theme) => {
+    if (theme === 'dark') {
+      themeIcon.textContent = '☀️';
+      themeText.textContent = 'Light Mode';
+    } else {
+      themeIcon.textContent = '🌙';
+      themeText.textContent = 'Dark Mode';
+    }
+  };
+
+  // 1. Check local storage for saved theme, default to 'light'
+  const currentTheme = localStorage.getItem('theme') || 'light';
+  
+  // 2. Apply the saved theme on initial load
+  document.documentElement.setAttribute('data-theme', currentTheme);
+  
+  // 3. Update the button UI on initial load
+  if (themeToggle) {
+    updateButtonUI(currentTheme);
+  }
+  
+  // 4. Listen for button clicks to swap themes
+  if (themeToggle) {
+    themeToggle.addEventListener('click', (e) => {
+      e.preventDefault();
+      
+      let theme = document.documentElement.getAttribute('data-theme');
+      let newTheme = theme === 'dark' ? 'light' : 'dark';
+      
+      document.documentElement.setAttribute('data-theme', newTheme);
+      localStorage.setItem('theme', newTheme);
+      
+      updateButtonUI(newTheme); // Update the button instantly
+    });
+  }
+});

--- a/assets/js/themeSwitcher.js
+++ b/assets/js/themeSwitcher.js
@@ -16,10 +16,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const isDark = theme === 'dark';
     if (themeIcon) themeIcon.textContent = isDark ? '☀️' : '🌙';
     if (themeText) themeText.textContent = isDark ? 'Light Mode' : 'Dark Mode';
-    if (themeToggle) {
-    themeToggle.setAttribute('aria-pressed', isDark ? 'true' : 'false');
-    themeToggle.setAttribute('aria-label', isDark ? 'Switch to light mode' : 'Switch to dark mode');
-  }
+   if (themeToggle) {
+      
+      themeToggle.setAttribute('aria-pressed', isDark ? 'true' : 'false');
+      themeToggle.setAttribute('aria-label', isDark ? 'Switch to light mode' : 'Switch to dark mode');
+    }
   };
 
   updateButtonUI(document.documentElement.getAttribute('data-theme') || 'light');

--- a/assets/js/themeSwitcher.js
+++ b/assets/js/themeSwitcher.js
@@ -2,41 +2,54 @@ document.addEventListener('DOMContentLoaded', () => {
   const themeToggle = document.getElementById('theme-toggle');
   const themeIcon = document.getElementById('theme-icon');
   const themeText = document.getElementById('theme-text');
-  
-  // Helper function to update the button's text and icon
-  const updateButtonUI = (theme) => {
-    if (theme === 'dark') {
-      themeIcon.textContent = '☀️';
-      themeText.textContent = 'Light Mode';
-    } else {
-      themeIcon.textContent = '🌙';
-      themeText.textContent = 'Dark Mode';
+
+  // Safe storage helpers — never throw, even if localStorage is blocked
+  const getStoredTheme = () => {
+    try {
+      return localStorage.getItem('theme');
+    } catch {
+      return null;
     }
   };
 
+  const setStoredTheme = (theme) => {
+    try {
+      localStorage.setItem('theme', theme);
+    } catch {
+      // Storage unavailable — theme just won't persist, no crash
+    }
+  };
+
+  // Normalize whatever we read into exactly 'light' or 'dark'
+  const normalizeTheme = (value) => (value === 'dark' ? 'dark' : 'light');
+
   // 1. Check local storage for saved theme, default to 'light'
-  const currentTheme = localStorage.getItem('theme') || 'light';
-  
+  const currentTheme = normalizeTheme(getStoredTheme());
+
   // 2. Apply the saved theme on initial load
   document.documentElement.setAttribute('data-theme', currentTheme);
-  
-  // 3. Update the button UI on initial load
-  if (themeToggle) {
-    updateButtonUI(currentTheme);
-  }
-  
+
+  // 3. Update the button UI on initial load (guard against missing elements)
+  const updateButtonUI = (theme) => {
+    if (themeIcon) themeIcon.textContent = theme === 'dark' ? '☀️' : '🌙';
+    if (themeText) themeText.textContent = theme === 'dark' ? 'Light Mode' : 'Dark Mode';
+    // Tell assistive tech the current state
+    if (themeToggle) themeToggle.setAttribute('aria-pressed', theme === 'dark' ? 'true' : 'false');
+  };
+
+  updateButtonUI(currentTheme);
+
   // 4. Listen for button clicks to swap themes
   if (themeToggle) {
     themeToggle.addEventListener('click', (e) => {
       e.preventDefault();
-      
-      let theme = document.documentElement.getAttribute('data-theme');
-      let newTheme = theme === 'dark' ? 'light' : 'dark';
-      
+
+      const theme = document.documentElement.getAttribute('data-theme');
+      const newTheme = theme === 'dark' ? 'light' : 'dark';
+
       document.documentElement.setAttribute('data-theme', newTheme);
-      localStorage.setItem('theme', newTheme);
-      
-      updateButtonUI(newTheme); // Update the button instantly
+      setStoredTheme(newTheme); // Safe write — won't throw
+      updateButtonUI(newTheme);
     });
   }
 });

--- a/assets/js/themeSwitcher.js
+++ b/assets/js/themeSwitcher.js
@@ -16,7 +16,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const isDark = theme === 'dark';
     if (themeIcon) themeIcon.textContent = isDark ? '☀️' : '🌙';
     if (themeText) themeText.textContent = isDark ? 'Light Mode' : 'Dark Mode';
-    if (themeToggle) themeToggle.setAttribute('aria-pressed', isDark ? 'true' : 'false');
+    if (themeToggle) {
+    themeToggle.setAttribute('aria-pressed', isDark ? 'true' : 'false');
+    themeToggle.setAttribute('aria-label', isDark ? 'Switch to light mode' : 'Switch to dark mode');
+  }
   };
 
   updateButtonUI(document.documentElement.getAttribute('data-theme') || 'light');

--- a/media/css/index.css
+++ b/media/css/index.css
@@ -68,6 +68,9 @@
   transition: all 0.3s ease;
 }
 
+.nav-theme {
+  margin-left: -15px; 
+}
 .theme-toggle-btn:hover {
   background: var(--off-white);
   border-color: var(--mid);
@@ -207,7 +210,7 @@ nav.scrolled {
 
 .nav-links a{
     text-decoration:none;
-    color:black;
+    color: var(--black);
     font-weight: 600;
 }
 
@@ -889,6 +892,18 @@ footer::before {
   .about-card-stack { height: 300px; }
   .footer-top { grid-template-columns: 1fr 1fr; gap: 40px; }
   .chapter-grid { grid-template-columns: 1fr; }
+
+  /* 1. Move the wrapper to the top of the mobile menu */
+  
+  .nav-theme { order: -1; margin-left: 0; padding: 10px 20px;}
+
+  /* 2. Hide the text on mobile screens */
+ 
+  #theme-text {  display: none;}
+
+  /* 3. Force the button into a circular icon shape */
+ 
+  .theme-toggle-btn {   width: 42px;height: 42px; padding: 0;border-radius: 50%; justify-content: center;}
 }
 
 @media (max-width: 768px) {

--- a/media/css/index.css
+++ b/media/css/index.css
@@ -904,7 +904,17 @@ footer::before {
   .hero-social-proof { gap: 16px; }
   .programs-header { flex-direction: column; align-items: flex-start; }
   .nav-cta .btn-ghost { display: none; }
-  
+  #theme-text { 
+  display: none;
+}
+
+.theme-toggle-btn { 
+  width: 42px; 
+  height: 42px; 
+  padding: 0;
+  border-radius: 50%; 
+  justify-content: center;
+}
 }
 
 @media (max-width: 480px) {

--- a/media/css/index.css
+++ b/media/css/index.css
@@ -892,17 +892,8 @@ footer::before {
   .about-card-stack { height: 300px; }
   .footer-top { grid-template-columns: 1fr 1fr; gap: 40px; }
   .chapter-grid { grid-template-columns: 1fr; }
-
-  /* 1. Move the wrapper to the top of the mobile menu */
-  
   .nav-theme { order: -1; margin-left: 0; padding: 10px 20px;}
-
-  /* 2. Hide the text on mobile screens */
- 
   #theme-text {  display: none;}
-
-  /* 3. Force the button into a circular icon shape */
- 
   .theme-toggle-btn {   width: 42px;height: 42px; padding: 0;border-radius: 50%; justify-content: center;}
 }
 
@@ -952,7 +943,6 @@ footer::before {
     z-index: 1000;
   }
 
-  /* When JS adds .open the menu is visible */
   .nav-links.open { display: flex; }
 
   .nav-links li { width: 100%; }

--- a/media/css/index.css
+++ b/media/css/index.css
@@ -29,6 +29,66 @@
   --font-body: 'Nunito', sans-serif;
   --transition: 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
+[data-theme="dark"] {
+  /* 1. Background Colors (Changed to dark) */
+  --white: #0d0d0d;       
+  --off-white: #1a1a1a;   
+  --cream: #222222;       
+
+  /* 2. Text Colors (Changed to light) */
+  --black: #ffffff;       
+  --dark: #f8f7f4;        
+  --mid: #a1a1a1;         
+  --muted: #6b6b6b;       
+
+  /* 3. Borders */
+  --border: #333333;      
+
+  /* 4. Shadows  */
+  --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 8px 32px rgba(0, 0, 0, 0.5);
+  --shadow-lg: 0 24px 64px rgba(0, 0, 0, 0.6);
+  
+
+}
+
+.theme-toggle-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px; 
+  background: transparent;
+  border: 2px solid var(--border);
+  color: var(--black);
+  padding: 8px 10px;
+  border-radius: var(--radius-md, 20px);
+  cursor: pointer;
+  font-family: var(--font-body, sans-serif);
+  font-size: 0.95rem;
+  font-weight: 600;
+  transition: all 0.3s ease;
+}
+
+.theme-toggle-btn:hover {
+  background: var(--off-white);
+  border-color: var(--mid);
+}
+
+
+[data-theme="dark"] .theme-toggle-btn {
+  background: #0d0d0d;
+  color: #ffffff;
+  border-color: #333333; 
+}
+
+
+
+
+
+
+
+
+
+
 
 html {
   scroll-behavior: smooth;

--- a/media/css/index.css
+++ b/media/css/index.css
@@ -47,7 +47,9 @@
   --shadow-md: 0 8px 32px rgba(0, 0, 0, 0.5);
   --shadow-lg: 0 24px 64px rgba(0, 0, 0, 0.6);
 }
-
+[data-theme="dark"] nav {
+  background: rgba(13, 13, 13, 0.85);
+}
 .theme-toggle-btn {
   display: flex;
   align-items: center;
@@ -885,16 +887,6 @@ footer::before {
     margin-left: 0;
     padding: 10px 20px;
   }
-  #theme-text { 
-    display: none;
-  }
-  .theme-toggle-btn { 
-    width: 42px; 
-    height: 42px; 
-    padding: 0;
-    border-radius: 50%; 
-    justify-content: center;
-  }
 }
  
 @media (max-width: 768px) {
@@ -912,6 +904,7 @@ footer::before {
   .hero-social-proof { gap: 16px; }
   .programs-header { flex-direction: column; align-items: flex-start; }
   .nav-cta .btn-ghost { display: none; }
+  
 }
 
 @media (max-width: 480px) {

--- a/media/css/index.css
+++ b/media/css/index.css
@@ -29,27 +29,23 @@
   --font-body: 'Nunito', sans-serif;
   --transition: 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
+
 [data-theme="dark"] {
   /* 1. Background Colors (Changed to dark) */
   --white: #0d0d0d;       
   --off-white: #1a1a1a;   
   --cream: #222222;       
-
   /* 2. Text Colors (Changed to light) */
   --black: #ffffff;       
   --dark: #f8f7f4;        
   --mid: #a1a1a1;         
   --muted: #6b6b6b;       
-
   /* 3. Borders */
   --border: #333333;      
-
   /* 4. Shadows  */
   --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.4);
   --shadow-md: 0 8px 32px rgba(0, 0, 0, 0.5);
   --shadow-lg: 0 24px 64px rgba(0, 0, 0, 0.6);
-  
-
 }
 
 .theme-toggle-btn {
@@ -65,7 +61,9 @@
   font-family: var(--font-body, sans-serif);
   font-size: 0.95rem;
   font-weight: 600;
-  transition: all 0.3s ease;
+   transition: background-color var(--transition),
+              border-color var(--transition),
+              color var(--transition);
 }
 
 .nav-theme {
@@ -78,20 +76,10 @@
 
 
 [data-theme="dark"] .theme-toggle-btn {
-  background: #0d0d0d;
-  color: #ffffff;
-  border-color: #333333; 
+  background: var(--white);
+  color: var(--black);
+  border-color: var(--border);
 }
-
-
-
-
-
-
-
-
-
-
 
 html {
   scroll-behavior: smooth;
@@ -892,11 +880,23 @@ footer::before {
   .about-card-stack { height: 300px; }
   .footer-top { grid-template-columns: 1fr 1fr; gap: 40px; }
   .chapter-grid { grid-template-columns: 1fr; }
-  .nav-theme { order: -1; margin-left: 0; padding: 10px 20px;}
-  #theme-text {  display: none;}
-  .theme-toggle-btn {   width: 42px;height: 42px; padding: 0;border-radius: 50%; justify-content: center;}
+  .nav-theme { 
+    order: -1;
+    margin-left: 0;
+    padding: 10px 20px;
+  }
+  #theme-text { 
+    display: none;
+  }
+  .theme-toggle-btn { 
+    width: 42px; 
+    height: 42px; 
+    padding: 0;
+    border-radius: 50%; 
+    justify-content: center;
+  }
 }
-
+ 
 @media (max-width: 768px) {
   nav { padding: 0 20px; }
   .nav-links { display: none; }


### PR DESCRIPTION
### Description
Added a persistent theme switcher to the main navigation bar utilizing `localStorage` to remember the user's preference and cleanly toggle CSS variables for dark/light modes. 

**Recent UI Updates:**
* Restructured the HTML to isolate the theme toggle button for independent mobile placement.
* Updated the mobile `@media` query to prioritize the button at the top of the mobile navigation menu.
* Applied `display: none` to the text span on mobile screens for a cleaner, icon-only UI.
* Adjusted the mobile button dimensions and `border-radius` to display as a perfectly circular icon.

### Related Issue
Closes #62

### Screenshots
<img width="617" height="812" alt="Screenshot 2026-08-08 163231" src="https://github.com/user-attachments/assets/01391264-1bd6-40b7-9c0d-a94721d2bd66" />
<img width="602" height="810" alt="Screenshot 2026-08-08 163239" src="https://github.com/user-attachments/assets/9128b393-c145-42d1-8e39-f1489e114f89" />
<img width="1912" height="1023" alt="Screenshot 2026-08-08 163204" src="https://github.com/user-attachments/assets/ef395a66-e9ec-49bf-abea-bcf1716bed98" />
<img width="1918" height="1017" alt="Screenshot 2026-08-08 163214" src="https://github.com/user-attachments/assets/c1968db7-e10d-4df0-bcd1-5fc65551a1e5" />


### Video

https://github.com/user-attachments/assets/83795ea1-6de5-489b-b5b8-72fba5fa58fa


